### PR TITLE
Preventing loss of classpath information on REPL start

### DIFF
--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -22,17 +22,21 @@
        (map vec)
        (map #(update-in % [0] edn/read-string))))
 
-(defn resolve-deps
+(defn resolve-try-deps!
   "Resolve newly-added try-dependencies, adding them to classpath."
   [project]
   ;; TODO: I don't think this resolves the full hierarchy of dependencies
-  (lein-cp/resolve-dependencies ::dependencies project :add-classpath? true)
-  project)
+  (lein-cp/resolve-dependencies ::dependencies project :add-classpath? true))
 
-(defn add-deps
-  "Add list of dependencies to project and resolve them"
+(defn add-try-deps
+  "Add list of try-dependencies to project."
   [deps project]
-  (assoc project ::dependencies deps))
+  (update-in project [::dependencies] (comp vec concat) deps))
+
+(defn start-repl!
+  "Run REPL inside the same process to avoid losing classpath information."
+  [project]
+  (lein-repl/repl (assoc project :eval-in :leiningen)))
 
 (defn ^:no-project-needed try
   "Launch REPL with specified dependencies available.
@@ -44,8 +48,6 @@
 
   NOTE: lein-try does not require []"
   [project & args]
-  (let [with-try-deps (partial add-deps (->dep-pairs args))]
-    (-> project
-      with-try-deps
-      resolve-deps
-      lein-repl/repl)))
+  (let [project (add-try-deps (->dep-pairs args) project)]
+    (resolve-try-deps! project)
+    (start-repl! project)))

--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -26,17 +26,19 @@
   "Resolve newly-added try-dependencies, adding them to classpath."
   [project]
   ;; TODO: I don't think this resolves the full hierarchy of dependencies
-  (lein-cp/resolve-dependencies ::dependencies project :add-classpath? true))
+  (lein-cp/resolve-dependencies :dependencies project :add-classpath? true))
 
 (defn add-try-deps
   "Add list of try-dependencies to project."
   [deps project]
-  (update-in project [::dependencies] (comp vec concat) deps))
+  (update-in project [:dependencies] (comp vec concat) deps))
 
 (defn start-repl!
   "Run REPL inside the same process to avoid losing classpath information."
   [project]
-  (lein-repl/repl (assoc project :eval-in :leiningen)))
+  (let [cfg {:host (lein-repl/repl-host project) 
+             :port (lein-repl/repl-port project)}]
+    (->> (lein-repl/server project cfg false) (lein-repl/client project))))
 
 (defn ^:no-project-needed try
   "Launch REPL with specified dependencies available.

--- a/test/leiningen/try_test.clj
+++ b/test/leiningen/try_test.clj
@@ -10,4 +10,7 @@
 
 (deftest add-deps-test
   (is (= {:leiningen.try/dependencies [[:a :b]]}
-         (add-deps [[:a :b]] {}))))
+         (add-try-deps [[:a :b]] {})))
+  (is (= {:leiningen.try/dependencies [[:a :b] [:c :d]]}
+         (add-try-deps [[:c :d]] {:leiningen.try/dependencies [[:a :b]]})))
+  )

--- a/test/leiningen/try_test.clj
+++ b/test/leiningen/try_test.clj
@@ -9,8 +9,8 @@
          (->dep-pairs ["[clj-time" "0.5.1]" "[http-kit" "2.1.5]"]))))
 
 (deftest add-deps-test
-  (is (= {:leiningen.try/dependencies [[:a :b]]}
+  (is (= {:dependencies [[:a :b]]}
          (add-try-deps [[:a :b]] {})))
-  (is (= {:leiningen.try/dependencies [[:a :b] [:c :d]]}
-         (add-try-deps [[:c :d]] {:leiningen.try/dependencies [[:a :b]]})))
+  (is (= {:dependencies [[:a :b] [:c :d]]}
+         (add-try-deps [[:c :d]] {:dependencies [[:a :b]]})))
   )


### PR DESCRIPTION
This pull request adds `:eval-in :leiningen` to the project map passed to `leiningen.repl/repl`, probably causing `leiningen.core.eval/eval-in-project` to be executed inside the current instead of a child process (see [here](https://github.com/technomancy/leiningen/blob/master/leiningen-core/src/leiningen/core/eval.clj#L211)). This retains classpath information that seems to get lost if a subprocess is created.

This should thus fix issue #3.

(Also, I renamed `resolve-deps` to `resolve-try-deps!` and `add-deps` to `add-try-deps`, hope that's okay.)
