### PR TITLE
Fallback to Leiningen 2.1.3 if starting REPL fails

### DIFF
--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -42,7 +42,7 @@
     (let [cfg {:host (#'lein-repl/repl-host project) 
                :port (#'lein-repl/repl-port project)}]
       (->> (lein-repl/server project cfg false) (lein-repl/client project)))
-    (catch Exception _
+    (catch clojure.lang.ArityException e
       ;; Assume exception is due to bad signatures on server/client
       ;; and fall back to making it work in Leiningen 2.1.3:
       (lein-repl/repl (assoc project :eval-in :leiningen)))))

--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -36,9 +36,16 @@
 (defn start-repl!
   "Run REPL inside the same process to avoid losing classpath information."
   [project]
-  (let [cfg {:host (lein-repl/repl-host project) 
-             :port (lein-repl/repl-port project)}]
-    (->> (lein-repl/server project cfg false) (lein-repl/client project))))
+  (try
+    ;; use #' to access private Vars so we can compile against
+    ;; Leiningen 2.1.3 even tho' this code will throw an exception:
+    (let [cfg {:host (#'lein-repl/repl-host project) 
+               :port (#'lein-repl/repl-port project)}]
+      (->> (lein-repl/server project cfg false) (lein-repl/client project)))
+    (catch Exception _
+      ;; Assume exception is due to bad signatures on server/client
+      ;; and fall back to making it work in Leiningen 2.1.3:
+      (lein-repl/repl (assoc project :eval-in :leiningen)))))
 
 (defn ^:no-project-needed try
   "Launch REPL with specified dependencies available.


### PR DESCRIPTION
This may not be the most discriminating way to determine Leiningen 2.2.0 vs 2.1.3 but at least catching the exception and attempting to start the REPL with the old API seems to work on 2.1.3 and should continue to work on 2.2.0.
