### PR TITLE
Using 'RELEASE' if no version is given 

### DIFF
--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -3,22 +3,40 @@
             [leiningen.core.classpath :as lein-cp]
             [clojure.edn :as edn]))
 
-(defn ->dep-pairs
+(defn- version-string?
+  "Check if a given String represents a version number."
+  [^String s]
+  (or (contains? #{"RELEASE" "LATEST"} s)
+      (Character/isDigit (first s))))
+
+(def ->dep-pairs
   "From a sequence of command-line args describing dependency-version pairs,
-  return a list of vector pairs. Square braces in arg strings are ignored.
+   return a list of vector pairs. Square braces in arg strings are ignored. If
+   no version is given, 'RELEASE' will be used.
 
   Example:
   (->dep-pairs [\"clj-time\" \"\\\"0.5.1\\\"]\"])
   ; -> ([clj-time \"0.5.1\"])
 
   (->dep-pairs [\"[clj-time\" \"\\\"0.5.1\\\"]\"])
-  ; -> ([clj-time \"0.5.1\"])"
-  [args]
-  (->> args
-       (map #(clojure.string/replace % #"\[|\]" ""))
-       (partition 2)
-       (map vec)
-       (map #(update-in % [0] edn/read-string))))
+  ; -> ([clj-time \"0.5.1\"])
+  
+  (->dep-pairs [\"clj-time\" \"conformity\"])
+  ; -> ([clj-time \"RELEASE\"] [conformity \"RELEASE\"])"
+  (letfn [(lazy-convert [args]
+            (lazy-seq 
+              (when (seq args)
+                (let [[^String artifact & rst] args
+                      artifact (edn/read-string artifact)]
+                  (if-let [[^String v & nxt] (seq rst)]
+                    (if (version-string? v)
+                      (cons [artifact v] (lazy-convert nxt))
+                      (cons [artifact "RELEASE"] (lazy-convert rst)))
+                    (vector [artifact "RELEASE"]))))))]
+    (fn [args]
+      (->> args
+        (map #(clojure.string/replace % #"\[|\]" ""))
+        lazy-convert))))
 
 (defn- resolve-try-deps!
   "Resolve newly-added try-dependencies, adding them to classpath."

--- a/test/leiningen/try_test.clj
+++ b/test/leiningen/try_test.clj
@@ -3,10 +3,31 @@
             [leiningen.try :refer :all]))
 
 (deftest ->dep-pairs-test
-  (is (= '[[clj-time "0.5.1"]]
-         (->dep-pairs ["[clj-time" "0.5.1]"])))
-  (is (= '[[clj-time "0.5.1"] [http-kit "2.1.5"]]
-         (->dep-pairs ["[clj-time" "0.5.1]" "[http-kit" "2.1.5]"]))))
+  (testing "the explicit use of version numbers"
+    (is (= '[[clj-time "0.5.1"]]
+           (->dep-pairs ["[clj-time" "0.5.1]"])))
+    (is (= '[[clj-time "0.5.1"] [http-kit "2.1.5"]]
+           (->dep-pairs ["[clj-time" "0.5.1]" "[http-kit" "2.1.5]"]))))
+  (testing "the implicit use of 'RELEASE' if no version number is given"
+    (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
+           (->dep-pairs ["clj-time" "[http-kit" "2.1.5]"])))
+    (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
+           (->dep-pairs ["[clj-time]" "[http-kit" "2.1.5]"])))
+    (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
+           (->dep-pairs ["[clj-time]" "http-kit" "2.1.5"])))
+    (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
+           (->dep-pairs ["clj-time" "http-kit" "2.1.5"])))
+    (is (= '[[clj-time "RELEASE"] [http-kit "RELEASE"]]
+           (->dep-pairs ["clj-time" "http-kit"])))
+    (is (= '[[clj-time "0.5.1"] [http-kit "RELEASE"]]
+           (->dep-pairs ["clj-time" "0.5.1" "http-kit"]))))
+  (testing "the explicit use of 'RELEASE'"
+    (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
+           (->dep-pairs ["[clj-time" "RELEASE]" "[http-kit" "2.1.5]"])))
+    (is (= '[[clj-time "RELEASE"] [http-kit "RELEASE"]]
+           (->dep-pairs ["[clj-time" "RELEASE]" "[http-kit" "RELEASE]"])))
+    (is (= '[[clj-time "RELEASE"] [http-kit "RELEASE"]]
+           (->dep-pairs ["clj-time" "http-kit" "RELEASE"])))))
 
 (deftest add-deps-test
   (let [add-try-deps #'leiningen.try/add-try-deps]


### PR DESCRIPTION
As discussed in #7, this pull request should enable lein-try to handle calls without explicit version numbers, e.g.:

```
lein try panoptic
```

The mechanism relies on the new function `version-string?` which determines if a given String represents a version number by checking against `"RELEASE"`, `"LATEST"` and whether it starts with a number or not. Since artifact IDs may not start with a number (Clojure symbols mustn't, at least), I think this will suffice. (Maybe the lowercase Strings `"release"` and `"latest"` should be included?)

**Example:**

``` bash
$ lein try panoptic
Retrieving panoptic/panoptic/0.2.1/panoptic-0.2.1.pom from clojars
Retrieving panoptic/panoptic/0.2.1/panoptic-0.2.1.jar from clojars
nREPL server started on port 34336
REPL-y 0.2.0
Clojure 1.5.1
    Docs: (doc function-name-here)
          (find-doc "part-of-name-here")
  Source: (source function-name-here)
 Javadoc: (javadoc java-object-or-class-here)
    Exit: Control+D or (exit) or (quit)

user=>
```
