### PR TITLE
Use Leiningen's task dispatch instead of starting the REPL directly

### DIFF
--- a/test/leiningen/try_test.clj
+++ b/test/leiningen/try_test.clj
@@ -31,7 +31,14 @@
 
 (deftest add-deps-test
   (let [add-try-deps #'leiningen.try/add-try-deps]
-    (is (= {:dependencies [[:a :b]]}
-           (add-try-deps [[:a :b]] {})))
-    (is (= {:dependencies [[:a :b] [:c :d]]}
-           (add-try-deps [[:c :d]] {:dependencies [[:a :b]]})))))
+    (is (= (add-try-deps [[:a :b]] {})
+           {:profiles {:try {:dependencies [[:a :b]]}}}))
+    (is (= (add-try-deps [[:a :b]] {:dependencies [[:c :d]]})
+           {:dependencies [[:c :d]]
+            :profiles {:try {:dependencies [[:a :b]]}}}))
+    (is (= (add-try-deps [[:c :d]] {:profiles {:try {:dependencies [[:a :b]]}}})
+           {:profiles {:try {:dependencies [[:a :b] [:c :d]]}}}))
+    (is (= (add-try-deps [[:e :f]] {:dependencies [[:c :d]]
+                                    :profiles {:try {:dependencies [[:a :b]]}}})
+           {:dependencies [[:c :d]]
+            :profiles {:try {:dependencies [[:a :b] [:e :f]]}}}))))


### PR DESCRIPTION
These changes simplify lein-try's code structure and internal logic a little bit. Changes include:
- add new dependencies to the profile `:try` instead of the global dependencies
- start REPL using `leiningen.core.main/apply-task`
- declare lein-try as `^:higher-order`

On my machine (...), both Leiningen 2.1.3 and 2.2.0 let the plugin operate correctly. 

Also, issue #11 is addressed, making it possible to use custom data readers _within_ existing projects. It seems as if some compilation/resolution step is missing when calling lein-try in a non-project environment. This is indicated by different startup times - taking longer within a project than outside - and maybe the output produced by `DEBUG=1 lein try ...` which includes the two (project-only) tasks `javac` and `compile`.
