### PR TITLE
Use clojure.core/read-string to drop 1.5+ dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,5 @@
   :url "https://github.com/rkneufeld/lein-try"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :profiles {:dev {:dependencies [[leiningen "2.2.0"]]}}
+  :profiles {:dev {:dependencies [[leiningen "2.1.3"]]}}
   :eval-in-leiningen true)

--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -25,8 +25,8 @@
   (letfn [(lazy-convert [args]
             (lazy-seq 
               (when (seq args)
-                (let [[^String artifact & rst] args
-                      artifact (read-string artifact)]
+                (let [[^String artifact-str & rst] args
+                      artifact (symbol artifact-str)]
                   (if-let [[^String v & nxt] (seq rst)]
                     (if (version-string? v)
                       (cons [artifact v] (lazy-convert nxt))

--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -1,7 +1,6 @@
 (ns leiningen.try
   (:require [leiningen.core.project :as prj]
-            [leiningen.core.main :as main]
-            [clojure.edn :as edn]))
+            [leiningen.core.main :as main]))
 
 (defn- version-string?
   "Check if a given String represents a version number."
@@ -20,14 +19,14 @@
 
   (->dep-pairs [\"[clj-time\" \"\\\"0.5.1\\\"]\"])
   ; -> ([clj-time \"0.5.1\"])
-  
+
   (->dep-pairs [\"clj-time\" \"conformity\"])
   ; -> ([clj-time \"RELEASE\"] [conformity \"RELEASE\"])"
   (letfn [(lazy-convert [args]
             (lazy-seq 
               (when (seq args)
                 (let [[^String artifact & rst] args
-                      artifact (edn/read-string artifact)]
+                      artifact (read-string artifact)]
                   (if-let [[^String v & nxt] (seq rst)]
                     (if (version-string? v)
                       (cons [artifact v] (lazy-convert nxt))


### PR DESCRIPTION
In my opinion, since we're reading user-supplied values from the
command-line, that it is acceptable to use clojure.core/read-string over
edn/read-string. Doing this would remove our reliance on any particular
version of Clojure.

/cc @xsc: what is your opinion on this?

Tagging along with this pull is a shift downward of the minimum lein
version to 2.1.3
