### PR TITLE
Remove square-brace syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Special thanks to contributors [@xsc](https://github.com/xsc) and [@seancorfield
 Put the following into the `:plugins` vector of the `:user` profile in your `~/.lein/profiles.clj`:
 
 ```clojure
-[lein-try "0.3.2"]
+[lein-try "0.4.0"]
 ```
 
 This plugin requires Leiningen >= 2.1.3.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Clojure libraries in a REPL without creating a project or adding them to an exis
 project.
 
 Special thanks to contributors [@xsc](https://github.com/xsc) and [@seancorfield](https://github.com/seancorfield) for making lein-try amazing.
+
 ## Usage
 
 #### Leiningen ([via Clojars](https://clojars.org/lein-try))
@@ -22,7 +23,7 @@ This plugin requires Leiningen >= 2.1.3.
 You can use `lein-try` to open a REPL with any dependencies you specify loaded and ready to use.
 
 ```bash
-$ lein try [clj-time "0.5.1"]
+$ lein try clj-time "0.5.1"
 Fetching dependencies... (takes a while the first time)
 lein-try loaded [clj-time "0.5.1"]
 
@@ -54,7 +55,7 @@ Launch REPL with specified dependencies available.
 
   Usage:
 
-    lein try [io.rkn/conformity "0.2.1"] [com.datomic/datomic-free "0.8.4020.26"]
+    lein try io.rkn/conformity "0.2.1" com.datomic/datomic-free "0.8.4020.26"
     lein try io.rkn/conformity 0.2.1
     lein try io.rkn/conformity # This uses the most recent version
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Clojure 1.5.1
 user=>
 ```
 
-You can even leave off the version number and leiningen will pull the most recently released version! (Thanks @xsc)
+You can even leave off the version number and leiningen will pull the most
+recently released version! (Thanks @xsc.) The command `lein try clj-time`
+evaluates as `lein try clj-time "RELEASE"`. Feel free to mix versioned and
+unversioned dependencies–we're good like that.
 
 ```bash
 $ lein try clj-time
@@ -69,15 +72,6 @@ Miss Emacs integration while `lein try`ing? In your `*scratch*` buffer, set your
 `(setq inferior-lisp-program "lein try tentacles")`
 
 and then launch `M-x inferior-lisp`.
-
-#### On ZSH
-
-[ZSH](zsh.org) has this fun feature where `[..]` is a special type of pattern matching–this kind of sucks for this plugin, no?
-
-You have two options to get around this:
-
-1. Use `noglob` before `lein try`. (If you never use `[]` matching with lein, just `alias lein="noglob lein"` in your zshrc.)
-2. Copy-paste *only* the library and dependency (i.e. `lein try clj-time "0.5.1"`)
 
 ## Contributions
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-try "0.3.3-SNAPSHOT"
+(defproject lein-try "0.4.0-SNAPSHOT"
   :description "Try out libraries without adding them as dependencies"
   :url "https://github.com/rkneufeld/lein-try"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/try.clj
+++ b/src/leiningen/try.clj
@@ -10,20 +10,20 @@
 
 (def ->dep-pairs
   "From a sequence of command-line args describing dependency-version pairs,
-   return a list of vector pairs. Square braces in arg strings are ignored. If
-   no version is given, 'RELEASE' will be used.
+  return a list of vector pairs. If no version is given, 'RELEASE' will be
+  used.
 
   Example:
   (->dep-pairs [\"clj-time\" \"\\\"0.5.1\\\"]\"])
   ; -> ([clj-time \"0.5.1\"])
 
-  (->dep-pairs [\"[clj-time\" \"\\\"0.5.1\\\"]\"])
+  (->dep-pairs [\"clj-time\" \"\\\"0.5.1\\\"\"])
   ; -> ([clj-time \"0.5.1\"])
 
   (->dep-pairs [\"clj-time\" \"conformity\"])
   ; -> ([clj-time \"RELEASE\"] [conformity \"RELEASE\"])"
   (letfn [(lazy-convert [args]
-            (lazy-seq 
+            (lazy-seq
               (when (seq args)
                 (let [[^String artifact-str & rst] args
                       artifact (symbol artifact-str)]
@@ -33,9 +33,7 @@
                       (cons [artifact "RELEASE"] (lazy-convert rst)))
                     (vector [artifact "RELEASE"]))))))]
     (fn [args]
-      (->> args
-        (map #(clojure.string/replace % #"\[|\]" ""))
-        lazy-convert))))
+      (lazy-convert args))))
 
 (defn- add-try-deps
   "Add list of try-dependencies to project."
@@ -45,7 +43,7 @@
 (defn- start-try-repl!
   "Resolve try-dependencies and start REPL."
   [project]
-  (let [project (when project 
+  (let [project (when project
                   (prj/merge-profiles
                     (prj/project-with-profiles project)
                     [:try]))]

--- a/test/leiningen/try_test.clj
+++ b/test/leiningen/try_test.clj
@@ -5,16 +5,16 @@
 (deftest ->dep-pairs-test
   (testing "the explicit use of version numbers"
     (is (= '[[clj-time "0.5.1"]]
-           (->dep-pairs ["[clj-time" "0.5.1]"])))
+           (->dep-pairs ["clj-time" "0.5.1"])))
     (is (= '[[clj-time "0.5.1"] [http-kit "2.1.5"]]
-           (->dep-pairs ["[clj-time" "0.5.1]" "[http-kit" "2.1.5]"]))))
+           (->dep-pairs ["clj-time" "0.5.1" "http-kit" "2.1.5"]))))
   (testing "the implicit use of 'RELEASE' if no version number is given"
     (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
-           (->dep-pairs ["clj-time" "[http-kit" "2.1.5]"])))
+           (->dep-pairs ["clj-time" "http-kit" "2.1.5"])))
     (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
-           (->dep-pairs ["[clj-time]" "[http-kit" "2.1.5]"])))
+           (->dep-pairs ["clj-time" "http-kit" "2.1.5"])))
     (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
-           (->dep-pairs ["[clj-time]" "http-kit" "2.1.5"])))
+           (->dep-pairs ["clj-time" "http-kit" "2.1.5"])))
     (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
            (->dep-pairs ["clj-time" "http-kit" "2.1.5"])))
     (is (= '[[clj-time "RELEASE"] [http-kit "RELEASE"]]
@@ -23,9 +23,9 @@
            (->dep-pairs ["clj-time" "0.5.1" "http-kit"]))))
   (testing "the explicit use of 'RELEASE'"
     (is (= '[[clj-time "RELEASE"] [http-kit "2.1.5"]]
-           (->dep-pairs ["[clj-time" "RELEASE]" "[http-kit" "2.1.5]"])))
+           (->dep-pairs ["clj-time" "RELEASE" "http-kit" "2.1.5"])))
     (is (= '[[clj-time "RELEASE"] [http-kit "RELEASE"]]
-           (->dep-pairs ["[clj-time" "RELEASE]" "[http-kit" "RELEASE]"])))
+           (->dep-pairs ["clj-time" "RELEASE" "http-kit" "RELEASE"])))
     (is (= '[[clj-time "RELEASE"] [http-kit "RELEASE"]]
            (->dep-pairs ["clj-time" "http-kit" "RELEASE"])))))
 


### PR DESCRIPTION
Dependencies specified inside of square-brackets are rather troublesome in both ZSH and BASH (both of which try to glob their contents).
- [x] Remove support for `[...]`-style arguments to the plugin.
- [x] Update README.md to suggest `lein try dep-name`-style, then `lein try dep-name version-num` as a follow-on.
- [x] Cut a 0.4.0 release. (@rkneufeld only, unless @xsc wants push and @rkneufeld docs the release process.)

---

Explanation of possible BASH behavior:

>  nDuff:    rkneufeld: so, [123] will be delivered to the program as '[123]', _unless_ the current directory contains a file named 1, a file named 2, or a file named 3, or the "nullglob" shell option is available.
