### PR TITLE
reduce :pedantic? to :warn if :abort is specified.

### DIFF
--- a/test/leiningen/try_test.clj
+++ b/test/leiningen/try_test.clj
@@ -42,3 +42,17 @@
                                     :profiles {:try {:dependencies [[:a :b]]}}})
            {:dependencies [[:c :d]]
             :profiles {:try {:dependencies [[:a :b] [:e :f]]}}}))))
+
+(deftest disable-pedantic-test
+  (let [disable-pedantic #'leiningen.try/disable-pedantic]
+    (are [project] (= (disable-pedantic project) project)
+         {}
+         {:pedantic? :warn}
+         {:pedantic? :none}
+         {:pedantic? :something-else})
+    (are [pedantic? result] (= (get-in (disable-pedantic {:pedantic? pedantic?})
+                                       [:profiles :try :pedantic?])
+                               result)
+         :abort  :warn
+         'abort  'warn
+         "abort" "warn")))


### PR DESCRIPTION
Reason: when checking if a dependency would suit an existing project (e.g. my project has a map of data somewhere and I want to serialize that data to JSON but want to try out different libraries) dependency conflicts will prevent the REPL from starting if `pedantic?` is set to `:abort`.

The user should be able to add the dependency, try it out and handle any such conflicts at a later point in time which is why this PR will reduce the `:pedantic?` level to `:warn` if it is `:abort`.
